### PR TITLE
Balancer permissioned pools

### DIFF
--- a/packages/liquidity-provision/package.json
+++ b/packages/liquidity-provision/package.json
@@ -59,7 +59,9 @@
     "@balancer-labs/v2-pool-weighted": "^2.0.1",
     "@balancer-labs/v2-solidity-utils": "^2.0.0",
     "@balancer-labs/v2-vault": "^2.0.0",
+    "@ethersproject/abi": "^5.4.0",
     "@ethersproject/bignumber": "^5.4.1",
+    "@ethersproject/bytes": "^5.4.0",
     "@ethersproject/constants": "^5.4.0",
     "@ethersproject/contracts": "^5.4.1",
     "@ethersproject/providers": "^5.4.5"

--- a/packages/pool-permissioned/.solhintignore
+++ b/packages/pool-permissioned/.solhintignore
@@ -1,0 +1,1 @@
+contracts/test/

--- a/packages/pool-permissioned/README.md
+++ b/packages/pool-permissioned/README.md
@@ -1,0 +1,11 @@
+# <img src="../../logo.svg" alt="Balancer" height="128px">
+
+# Balancer V2 Permissioned Pools
+
+`pool-permissioned` is an example of a pool that limits participation to an allowlist
+
+## Overview
+
+## Licensing
+
+[GNU General Public License Version 3 (GPL v3)](../../LICENSE).

--- a/packages/pool-permissioned/contracts/PermissionedPool.sol
+++ b/packages/pool-permissioned/contracts/PermissionedPool.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-pool-weighted/contracts/WeightedPool.sol";
+import "./interfaces/IPermissionedPool.sol";
+import "./interfaces/IPermissionedRegistry.sol";
+
+/**
+ * @dev PermissionedPool with an allowlist
+ */
+contract PermissionedPool is IPermissionedPool, WeightedPool {
+    bytes32 private immutable _allowlistId;
+    IPermissionedRegistry private immutable _allowlistRegistry;
+
+    struct NewPoolParams {
+        IVault vault;
+        string name;
+        string symbol;
+        IERC20[] tokens;
+        uint256[] normalizedWeights;
+        address[] assetManagers;
+        uint256 swapFeePercentage;
+        uint256 pauseWindowDuration;
+        uint256 bufferPeriodDuration;
+        address owner;
+        address allowlistRegistry;
+        bytes32 allowlistId;
+    }
+
+    constructor(NewPoolParams memory params)
+        WeightedPool(
+            params.vault,
+            params.name,
+            params.symbol,
+            params.tokens,
+            params.normalizedWeights,
+            params.assetManagers,
+            params.swapFeePercentage,
+            params.pauseWindowDuration,
+            params.bufferPeriodDuration,
+            params.owner
+        )
+    {
+        _allowlistId = params.allowlistId;
+        _allowlistRegistry = IPermissionedRegistry(params.allowlistRegistry);
+    }
+
+    /**
+     * @dev Verifies that a given address is allowed to hold tokens.
+     */
+    function canReceiveBPT(address member, uint256) public view override returns (bool) {
+        if (member == address(0)) return true;
+        return _allowlistRegistry.isAllowlisted(_allowlistId, member);
+    }
+
+    /**
+     * @dev Verifies that a given address is allowed to swap tokens
+     */
+    function isAllowedSwap(SwapRequest memory swapRequest) public view override returns (bool) {
+        return
+            _allowlistRegistry.isAllowlisted(_allowlistId, swapRequest.from) &&
+            _allowlistRegistry.isAllowlisted(_allowlistId, swapRequest.to);
+    }
+
+    /**
+     * @dev Override _beforeTokenTransfer to limit transfers of bpt
+     */
+    function _beforeTokenTransfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(canReceiveBPT(recipient, amount), "Invalid bpt recipient");
+        return super._beforeTokenTransfer(sender, recipient, amount);
+    }
+
+    /**
+     * @dev Override _onJoinPool to remove protocolFees
+     */
+    function _onJoinPool(
+        bytes32 poolId,
+        address sender,
+        address recipient,
+        uint256[] memory balances,
+        uint256 lastChangeBlock,
+        uint256, // protocolSwapFeePercentage,
+        uint256[] memory scalingFactors,
+        bytes memory userData
+    )
+        internal
+        virtual
+        override
+        whenNotPaused
+        returns (
+            uint256 bptAmountOut,
+            uint256[] memory amountsIn,
+            uint256[] memory dueProtocolFeeAmounts
+        )
+    {
+        return super._onJoinPool(poolId, sender, recipient, balances, lastChangeBlock, 0, scalingFactors, userData);
+    }
+
+    /**
+     * @dev Override _onExitPool to remove protocolFees
+     */
+    function _onExitPool(
+        bytes32 poolId,
+        address sender,
+        address recipient,
+        uint256[] memory balances,
+        uint256 lastChangeBlock,
+        uint256, // protocolSwapFeePercentage,
+        uint256[] memory scalingFactors,
+        bytes memory userData
+    )
+        internal
+        virtual
+        override
+        returns (
+            uint256 bptAmountIn,
+            uint256[] memory amountsOut,
+            uint256[] memory dueProtocolFeeAmounts
+        )
+    {
+        return super._onExitPool(poolId, sender, recipient, balances, lastChangeBlock, 0, scalingFactors, userData);
+    }
+
+    /**
+     * @dev Override _onExitPool to remove protocolFees
+     */
+    function _onSwapGivenIn(
+        SwapRequest memory swapRequest,
+        uint256 currentBalanceTokenIn,
+        uint256 currentBalanceTokenOut
+    ) internal view virtual override whenNotPaused returns (uint256) {
+        require(isAllowedSwap(swapRequest), "Swap not allowed");
+        return super._onSwapGivenIn(swapRequest, currentBalanceTokenIn, currentBalanceTokenOut);
+    }
+
+    function _onSwapGivenOut(
+        SwapRequest memory swapRequest,
+        uint256 currentBalanceTokenIn,
+        uint256 currentBalanceTokenOut
+    ) internal view virtual override whenNotPaused returns (uint256) {
+        require(isAllowedSwap(swapRequest), "Swap not allowed");
+        return super._onSwapGivenOut(swapRequest, currentBalanceTokenIn, currentBalanceTokenOut);
+    }
+}

--- a/packages/pool-permissioned/contracts/PermissionedRegistry.sol
+++ b/packages/pool-permissioned/contracts/PermissionedRegistry.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "./interfaces/IPermissionedRegistry.sol";
+
+/**
+ * @dev PermissionedRegistry is a registry of allowlists
+ */
+contract PermissionedRegistry is IPermissionedRegistry {
+    mapping(bytes32 => address) private _allowlistOwners;
+    mapping(bytes32 => mapping(address => bool)) private _allowlists;
+
+    function createAllowlist(bytes32 allowlistId) public {
+        require(_allowlistOwners[allowlistId] == address(0), "allowlist already has an owner");
+        _allowlistOwners[allowlistId] = msg.sender;
+    }
+
+    function isAllowlisted(bytes32 allowlistId, address member) external view override returns (bool) {
+        return _allowlists[allowlistId][member];
+    }
+
+    /**
+     * @dev Adds an address to the allowlist.
+     */
+    function addAllowedAddress(bytes32 allowlistId, address member) external {
+        require(_allowlistOwners[allowlistId] == msg.sender, "not allowlist owner");
+        require(!_allowlists[allowlistId][member], "address already allowlisted");
+
+        _allowlists[allowlistId][member] = true;
+    }
+
+    /**
+     * @dev Removes an address from the allowlist.
+     */
+    function removeAllowedAddress(bytes32 allowlistId, address member) external {
+        require(_allowlistOwners[allowlistId] == msg.sender, "not allowlist owner");
+
+        delete _allowlists[allowlistId][member];
+    }
+}

--- a/packages/pool-permissioned/contracts/interfaces/IPermissionedPool.sol
+++ b/packages/pool-permissioned/contracts/interfaces/IPermissionedPool.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-vault/contracts/interfaces/IPoolSwapStructs.sol";
+
+interface IPermissionedPool is IPoolSwapStructs {
+    function canReceiveBPT(address member, uint256) external view returns (bool);
+
+    function isAllowedSwap(SwapRequest memory swapRequest) external view returns (bool);
+}

--- a/packages/pool-permissioned/contracts/interfaces/IPermissionedRegistry.sol
+++ b/packages/pool-permissioned/contracts/interfaces/IPermissionedRegistry.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+interface IPermissionedRegistry {
+    function isAllowlisted(bytes32 allowlistId, address member) external view returns (bool);
+}

--- a/packages/pool-permissioned/hardhat.config.ts
+++ b/packages/pool-permissioned/hardhat.config.ts
@@ -1,0 +1,23 @@
+import { HardhatUserConfig } from 'hardhat/config';
+
+import '@nomiclabs/hardhat-ethers';
+import '@nomiclabs/hardhat-waffle';
+
+const config: HardhatUserConfig = {
+  solidity: {
+    version: '0.7.1',
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 9999,
+      },
+    },
+  },
+  networks: {
+    hardhat: {
+      allowUnlimitedContractSize: true,
+    },
+  },
+};
+
+export default config;

--- a/packages/pool-permissioned/package.json
+++ b/packages/pool-permissioned/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@balancer-examples/pool-permissioned",
+  "private": true,
+  "description": "Example permissioned pool type",
+  "license": "GPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/balancer-labs/balancer-quickstart-template.git",
+    "directory": "package/pool-permissioned"
+  },
+  "bugs": {
+    "url": "https://github.com/balancer-labs/balancer-quickstart-template/issues"
+  },
+  "files": [
+    "contracts/**/*",
+    "!contracts/test/*"
+  ],
+  "scripts": {
+    "build": "yarn compile",
+    "compile": "hardhat compile",
+    "compile:watch": "nodemon --ext sol --exec yarn compile",
+    "lint": "yarn lint:solidity && yarn lint:typescript",
+    "lint:solidity": "solhint 'contracts/**/*.sol'",
+    "lint:typescript": "eslint . --ext .ts --ignore-path ../../.eslintignore  --max-warnings 0",
+    "test": "yarn compile && mocha --extension ts --require hardhat/register --recursive",
+    "testhh": "hardhat test",
+    "test:fast": "yarn compile && mocha --extension ts --require hardhat/register --recursive --parallel --exit",
+    "test:watch": "nodemon --ext js,ts --watch test --watch lib --exec 'clear && yarn test --no-compile'"
+  },
+  "devDependencies": {
+    "@balancer-labs/typechain": "^1.0.0",
+    "@ethersproject/abi": "^5.4.0",
+    "@ethersproject/bytes": "^5.4.0",
+    "@ethersproject/constants": "^5.4.0",
+    "@ethersproject/providers": "^5.4.5",
+    "@nomiclabs/hardhat-ethers": "^2.0.1",
+    "@nomiclabs/hardhat-waffle": "^2.0.0",
+    "@types/chai": "^4.2.12",
+    "@types/mocha": "^8.0.3",
+    "@types/node": "^14.6.0",
+    "@typescript-eslint/eslint-plugin": "^4.1.1",
+    "@typescript-eslint/parser": "^4.1.1",
+    "chai": "^4.2.0",
+    "eslint": "^7.32.0",
+    "eslint-plugin-mocha-no-only": "^1.1.1",
+    "eslint-plugin-prettier": "^4.0.0",
+    "ethereum-waffle": "^3.0.2",
+    "ethers": "^5.4.1",
+    "hardhat": "^2.4.1",
+    "mocha": "^8.2.1",
+    "nodemon": "^2.0.4",
+    "prettier": "^2.4.0",
+    "prettier-plugin-solidity": "^1.0.0-beta.18",
+    "solhint": "^3.2.0",
+    "solhint-plugin-prettier": "^0.0.5",
+    "ts-node": "^8.10.2",
+    "typescript": "^4.0.2"
+  },
+  "dependencies": {
+    "@balancer-labs/v2-deployments": "^2.0.1",
+    "@balancer-labs/v2-pool-utils": "^2.0.1",
+    "@balancer-labs/v2-solidity-utils": "^2.0.0",
+    "@balancer-labs/v2-vault": "^2.0.0",
+    "@ethersproject/contracts": "5.4.0"
+  }
+}

--- a/packages/pool-permissioned/test/PermissionedPool.test.ts
+++ b/packages/pool-permissioned/test/PermissionedPool.test.ts
@@ -1,0 +1,199 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Vault } from '@balancer-labs/typechain';
+
+import {
+  TokenList,
+  setupEnvironment,
+  pickTokenAddresses,
+  txConfirmation,
+} from '@balancer-examples/shared-dependencies';
+import { fp } from '@balancer-examples/shared-dependencies/numbers';
+import { toNormalizedWeights, FundManagement, BatchSwapStep, SwapKind } from '@balancer-labs/balancer-js';
+import { Contract } from '@ethersproject/contracts';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+import { WeightedPoolEncoder } from '@balancer-labs/balancer-js';
+
+import { MaxUint256 } from '@ethersproject/constants';
+
+export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const tokenAmount = fp(100);
+
+describe('PermissionedPool', function () {
+  let vault: Vault;
+  let tokens: TokenList;
+  let tokenAddresses: string[];
+  let deployer: SignerWithAddress;
+  let liquidityProvider: SignerWithAddress;
+  let trader: SignerWithAddress;
+  let poolId: string;
+
+  const allowlistId = '0x0000000000000000000000000000000000000000000000000000000000000001';
+
+  const POOL_SWAP_FEE_PERCENTAGE = fp(0.01);
+  const WEIGHTS = toNormalizedWeights([fp(30), fp(70)]);
+
+  beforeEach('deploy tokens', async () => {
+    ({ vault, tokens, deployer, trader, liquidityProvider } = await setupEnvironment());
+    tokenAddresses = pickTokenAddresses(tokens, 2);
+  });
+
+  async function deployPermissionedRegistry(): Promise<Contract> {
+    const PermissionedRegistry = await ethers.getContractFactory('PermissionedRegistry');
+    const permissionedRegistry = await PermissionedRegistry.deploy();
+    const instance: Contract = await permissionedRegistry.deployed();
+    return instance;
+  }
+
+  async function deployPermissionedPool(params: unknown[]): Promise<Contract> {
+    const PermissionedPool = await ethers.getContractFactory('PermissionedPool');
+    const permissionedPool = await PermissionedPool.deploy(params);
+    const instance: Contract = await permissionedPool.deployed();
+    return instance;
+  }
+
+  describe('weights and scaling factors', () => {
+    context(`with WETH and DAI tokens`, () => {
+      let pool: Contract;
+      let registry: Contract;
+
+      beforeEach('deploy pool', async () => {
+        // TODO
+        registry = await deployPermissionedRegistry();
+        await registry.createAllowlist(allowlistId);
+
+        const params = [
+          vault.address,
+          'test pool',
+          'TEST',
+          tokenAddresses,
+          WEIGHTS,
+          [ZERO_ADDRESS, ZERO_ADDRESS],
+          POOL_SWAP_FEE_PERCENTAGE,
+          100,
+          100,
+          deployer.address,
+          registry.address,
+          allowlistId,
+        ];
+
+        pool = await deployPermissionedPool(params);
+        poolId = await pool.getPoolId();
+      });
+
+      it('reverts when an unapproved LP attempts to join', () => {
+        const userData = WeightedPoolEncoder.joinInit(tokenAddresses.map(() => tokenAmount));
+
+        const joinRequest = {
+          assets: tokenAddresses,
+          maxAmountsIn: tokenAddresses.map(() => MaxUint256),
+          userData,
+          fromInternalBalance: false,
+        };
+
+        expect(
+          vault
+            .connect(liquidityProvider)
+            .joinPool(poolId, liquidityProvider.address, liquidityProvider.address, joinRequest)
+        ).to.be.revertedWith('account is not allowlisted');
+      });
+
+      context('when a LP has been allowlisted', () => {
+        beforeEach('allowlist LP', async () => {
+          await registry.addAllowedAddress(allowlistId, liquidityProvider.address);
+        });
+
+        it('allows an approved LP to join', async () => {
+          const userData = WeightedPoolEncoder.joinInit(tokenAddresses.map(() => tokenAmount));
+
+          const joinRequest = {
+            assets: tokenAddresses,
+            maxAmountsIn: tokenAddresses.map(() => MaxUint256),
+            userData,
+            fromInternalBalance: false,
+          };
+
+          await txConfirmation(
+            vault
+              .connect(liquidityProvider)
+              .joinPool(poolId, liquidityProvider.address, liquidityProvider.address, joinRequest)
+          );
+        });
+
+        context('when pool has been initialized', () => {
+          beforeEach('initialize pool', async () => {
+            const userData = WeightedPoolEncoder.joinInit(tokenAddresses.map(() => tokenAmount));
+
+            const joinRequest = {
+              assets: tokenAddresses,
+              maxAmountsIn: tokenAddresses.map(() => MaxUint256),
+              userData,
+              fromInternalBalance: false,
+            };
+
+            await txConfirmation(
+              vault
+                .connect(liquidityProvider)
+                .joinPool(poolId, liquidityProvider.address, liquidityProvider.address, joinRequest)
+            );
+          });
+
+          it('allows trader to swap when approved', async () => {
+            await registry.addAllowedAddress(allowlistId, trader.address);
+
+            const amount = fp(5);
+            const funds: FundManagement = {
+              sender: trader.address,
+              fromInternalBalance: false,
+              recipient: trader.address,
+              toInternalBalance: false,
+            };
+
+            const deadline = MaxUint256;
+
+            const step1: BatchSwapStep = {
+              poolId,
+              assetInIndex: 0,
+              assetOutIndex: 1,
+              amount,
+              userData: '0x',
+            };
+
+            const swaps = [step1];
+            const limits = tokenAddresses.map(() => fp(1000));
+            await txConfirmation(
+              vault.connect(trader).batchSwap(SwapKind.GivenIn, swaps, tokenAddresses, funds, limits, deadline)
+            );
+          });
+
+          it('reverts when trader is unapproved', async () => {
+            const amount = fp(5);
+            const funds: FundManagement = {
+              sender: trader.address,
+              fromInternalBalance: false,
+              recipient: trader.address,
+              toInternalBalance: false,
+            };
+
+            const deadline = MaxUint256;
+
+            const step1: BatchSwapStep = {
+              poolId,
+              assetInIndex: 0,
+              assetOutIndex: 1,
+              amount,
+              userData: '0x',
+            };
+
+            const swaps = [step1];
+            const limits = tokenAddresses.map(() => fp(1000));
+            await expect(
+              vault.connect(trader).batchSwap(SwapKind.GivenIn, swaps, tokenAddresses, funds, limits, deadline)
+            ).to.be.revertedWith('Swap not allowed');
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/pool-permissioned/test/PermissionedPool.test.ts
+++ b/packages/pool-permissioned/test/PermissionedPool.test.ts
@@ -19,6 +19,7 @@ import { MaxUint256 } from '@ethersproject/constants';
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 const tokenAmount = fp(100);
+const tokenExitAmount = fp(10);
 
 describe('PermissionedPool', function () {
   let vault: Vault;
@@ -167,6 +168,35 @@ describe('PermissionedPool', function () {
             );
           });
 
+          it('reverts when trader is approved and then unapproved', async () => {
+            await registry.addAllowedAddress(allowlistId, trader.address);
+            await registry.removeAllowedAddress(allowlistId, trader.address);
+
+            const amount = fp(5);
+            const funds: FundManagement = {
+              sender: trader.address,
+              fromInternalBalance: false,
+              recipient: trader.address,
+              toInternalBalance: false,
+            };
+
+            const deadline = MaxUint256;
+
+            const step1: BatchSwapStep = {
+              poolId,
+              assetInIndex: 0,
+              assetOutIndex: 1,
+              amount,
+              userData: '0x',
+            };
+
+            const swaps = [step1];
+            const limits = tokenAddresses.map(() => fp(1000));
+            await expect(
+              vault.connect(trader).batchSwap(SwapKind.GivenIn, swaps, tokenAddresses, funds, limits, deadline)
+            ).to.be.revertedWith('Swap not allowed');
+          });
+
           it('reverts when trader is unapproved', async () => {
             const amount = fp(5);
             const funds: FundManagement = {
@@ -192,6 +222,41 @@ describe('PermissionedPool', function () {
               vault.connect(trader).batchSwap(SwapKind.GivenIn, swaps, tokenAddresses, funds, limits, deadline)
             ).to.be.revertedWith('Swap not allowed');
           });
+
+          it('allows an approved LP to exit', async () => {
+          const userData = WeightedPoolEncoder.exitBPTInForExactTokensOut(tokenAddresses.map(() => tokenExitAmount), MaxUint256);
+
+          const exitRequest = {
+            assets: tokenAddresses,
+            minAmountsOut: tokenAddresses.map(() => (0.0)),
+            userData,
+            toInternalBalance: false,
+          };
+
+          await txConfirmation(
+            vault
+              .connect(liquidityProvider)
+              .exitPool(poolId, liquidityProvider.address, liquidityProvider.address, exitRequest));
+          });
+
+          it('reverts when a previously approved but now disallowed LP tries to exit', async () => {
+          await registry.removeAllowedAddress(allowlistId, trader.address);
+
+          const userData = WeightedPoolEncoder.exitBPTInForExactTokensOut(tokenAddresses.map(() => tokenExitAmount), MaxUint256);
+
+          const exitRequest = {
+            assets: tokenAddresses,
+            minAmountsOut: tokenAddresses.map(() => (0.0)),
+            userData,
+            toInternalBalance: false,
+          };
+
+          await txConfirmation(
+            vault
+              .connect(liquidityProvider)
+              .exitPool(poolId, liquidityProvider.address, liquidityProvider.address, exitRequest));
+          });
+
         });
       });
     });

--- a/packages/pool-permissioned/test/PermissionedPool.test.ts
+++ b/packages/pool-permissioned/test/PermissionedPool.test.ts
@@ -224,11 +224,14 @@ describe('PermissionedPool', function () {
           });
 
           it('allows an approved LP to exit', async () => {
-            const userData = WeightedPoolEncoder.exitBPTInForExactTokensOut(tokenAddresses.map(() => tokenExitAmount), MaxUint256);
+            const userData = WeightedPoolEncoder.exitBPTInForExactTokensOut(
+              tokenAddresses.map(() => tokenExitAmount),
+              MaxUint256
+            );
 
             const exitRequest = {
               assets: tokenAddresses,
-              minAmountsOut: tokenAddresses.map(() => (0.0)),
+              minAmountsOut: tokenAddresses.map(() => fp(0)),
               userData,
               toInternalBalance: false,
             };
@@ -236,17 +239,21 @@ describe('PermissionedPool', function () {
             await txConfirmation(
               vault
                 .connect(liquidityProvider)
-                .exitPool(poolId, liquidityProvider.address, liquidityProvider.address, exitRequest));
+                .exitPool(poolId, liquidityProvider.address, liquidityProvider.address, exitRequest)
+            );
           });
 
           it('reverts when a previously approved but now disallowed LP tries to exit', async () => {
             await registry.removeAllowedAddress(allowlistId, trader.address);
 
-            const userData = WeightedPoolEncoder.exitBPTInForExactTokensOut(tokenAddresses.map(() => tokenExitAmount), MaxUint256);
+            const userData = WeightedPoolEncoder.exitBPTInForExactTokensOut(
+              tokenAddresses.map(() => tokenExitAmount),
+              MaxUint256
+            );
 
             const exitRequest = {
               assets: tokenAddresses,
-              minAmountsOut: tokenAddresses.map(() => (0.0)),
+              minAmountsOut: tokenAddresses.map(() => fp(0)),
               userData,
               toInternalBalance: false,
             };
@@ -254,9 +261,9 @@ describe('PermissionedPool', function () {
             await txConfirmation(
               vault
                 .connect(liquidityProvider)
-                .exitPool(poolId, liquidityProvider.address, liquidityProvider.address, exitRequest));
+                .exitPool(poolId, liquidityProvider.address, liquidityProvider.address, exitRequest)
+            );
           });
-
         });
       });
     });

--- a/packages/pool-permissioned/test/PermissionedPool.test.ts
+++ b/packages/pool-permissioned/test/PermissionedPool.test.ts
@@ -224,37 +224,37 @@ describe('PermissionedPool', function () {
           });
 
           it('allows an approved LP to exit', async () => {
-          const userData = WeightedPoolEncoder.exitBPTInForExactTokensOut(tokenAddresses.map(() => tokenExitAmount), MaxUint256);
+            const userData = WeightedPoolEncoder.exitBPTInForExactTokensOut(tokenAddresses.map(() => tokenExitAmount), MaxUint256);
 
-          const exitRequest = {
-            assets: tokenAddresses,
-            minAmountsOut: tokenAddresses.map(() => (0.0)),
-            userData,
-            toInternalBalance: false,
-          };
+            const exitRequest = {
+              assets: tokenAddresses,
+              minAmountsOut: tokenAddresses.map(() => (0.0)),
+              userData,
+              toInternalBalance: false,
+            };
 
-          await txConfirmation(
-            vault
-              .connect(liquidityProvider)
-              .exitPool(poolId, liquidityProvider.address, liquidityProvider.address, exitRequest));
+            await txConfirmation(
+              vault
+                .connect(liquidityProvider)
+                .exitPool(poolId, liquidityProvider.address, liquidityProvider.address, exitRequest));
           });
 
           it('reverts when a previously approved but now disallowed LP tries to exit', async () => {
-          await registry.removeAllowedAddress(allowlistId, trader.address);
+            await registry.removeAllowedAddress(allowlistId, trader.address);
 
-          const userData = WeightedPoolEncoder.exitBPTInForExactTokensOut(tokenAddresses.map(() => tokenExitAmount), MaxUint256);
+            const userData = WeightedPoolEncoder.exitBPTInForExactTokensOut(tokenAddresses.map(() => tokenExitAmount), MaxUint256);
 
-          const exitRequest = {
-            assets: tokenAddresses,
-            minAmountsOut: tokenAddresses.map(() => (0.0)),
-            userData,
-            toInternalBalance: false,
-          };
+            const exitRequest = {
+              assets: tokenAddresses,
+              minAmountsOut: tokenAddresses.map(() => (0.0)),
+              userData,
+              toInternalBalance: false,
+            };
 
-          await txConfirmation(
-            vault
-              .connect(liquidityProvider)
-              .exitPool(poolId, liquidityProvider.address, liquidityProvider.address, exitRequest));
+            await txConfirmation(
+              vault
+                .connect(liquidityProvider)
+                .exitPool(poolId, liquidityProvider.address, liquidityProvider.address, exitRequest));
           });
 
         });

--- a/packages/pool-permissioned/tsconfig.json
+++ b/packages/pool-permissioned/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["./test"],
+  "files": ["./hardhat.config.ts"]
+}

--- a/packages/shared-dependencies/numbers.ts
+++ b/packages/shared-dependencies/numbers.ts
@@ -1,0 +1,110 @@
+import { Decimal } from 'decimal.js';
+import { BigNumber } from 'ethers';
+
+const SCALING_FACTOR = 1e18;
+
+export type BigNumberish = string | number | BigNumber;
+
+export const decimal = (x: BigNumberish | Decimal): Decimal => new Decimal(x.toString());
+
+export const fp = (x: BigNumberish | Decimal): BigNumber => bn(toFp(x));
+
+export const toFp = (x: BigNumberish | Decimal): Decimal => decimal(x).mul(SCALING_FACTOR);
+
+export const fromFp = (x: BigNumberish | Decimal): Decimal => decimal(x).div(SCALING_FACTOR);
+
+export const bn = (x: BigNumberish | Decimal): BigNumber => {
+  if (BigNumber.isBigNumber(x)) return x;
+  const stringified = parseScientific(x.toString());
+  const integer = stringified.split('.')[0];
+  return BigNumber.from(integer);
+};
+
+export const maxUint = (e: number): BigNumber => bn(2).pow(e).sub(1);
+
+export const maxInt = (e: number): BigNumber => bn(2).pow(bn(e).sub(1)).sub(1);
+
+export const minInt = (e: number): BigNumber => bn(2).pow(bn(e).sub(1)).mul(-1);
+
+export const pct = (x: BigNumberish, pct: BigNumberish): BigNumber => bn(decimal(x).mul(decimal(pct)));
+
+export const max = (a: BigNumberish, b: BigNumberish): BigNumber => {
+  a = bn(a);
+  b = bn(b);
+
+  return a.gt(b) ? a : b;
+};
+
+export const min = (a: BigNumberish, b: BigNumberish): BigNumber => {
+  a = bn(a);
+  b = bn(b);
+
+  return a.lt(b) ? a : b;
+};
+
+export const arrayAdd = (arrA: BigNumberish[], arrB: BigNumberish[]): BigNumber[] =>
+  arrA.map((a, i) => bn(a).add(bn(arrB[i])));
+
+export const arraySub = (arrA: BigNumberish[], arrB: BigNumberish[]): BigNumber[] =>
+  arrA.map((a, i) => bn(a).sub(bn(arrB[i])));
+
+export const divCeil = (x: BigNumber, y: BigNumber): BigNumber =>
+  // ceil(x/y) == (x + y - 1) / y
+  x.add(y).sub(1).div(y);
+
+export const FP_SCALING_FACTOR = bn(SCALING_FACTOR);
+
+export function printGas(gas: number | BigNumber): string {
+  if (typeof gas !== 'number') {
+    gas = gas.toNumber();
+  }
+
+  return `${(gas / 1000).toFixed(1)}k`;
+}
+
+export function scaleUp(n: BigNumber, scalingFactor: BigNumber): BigNumber {
+  if (scalingFactor == bn(1)) {
+    return n;
+  }
+
+  return n.mul(scalingFactor);
+}
+
+export function scaleDown(n: BigNumber, scalingFactor: BigNumber): BigNumber {
+  if (scalingFactor == bn(1)) {
+    return n;
+  }
+
+  return n.div(scalingFactor);
+}
+
+function parseScientific(num: string): string {
+  // If the number is not in scientific notation return it as it is
+  if (!/\d+\.?\d*e[+-]*\d+/i.test(num)) return num;
+
+  // Remove the sign
+  const numberSign = Math.sign(Number(num));
+  num = Math.abs(Number(num)).toString();
+
+  // Parse into coefficient and exponent
+  const [coefficient, exponent] = num.toLowerCase().split('e');
+  let zeros = Math.abs(Number(exponent));
+  const exponentSign = Math.sign(Number(exponent));
+  const [integer, decimals] = (coefficient.indexOf('.') != -1 ? coefficient : `${coefficient}.`).split('.');
+
+  if (exponentSign === -1) {
+    zeros -= integer.length;
+    num =
+      zeros < 0
+        ? integer.slice(0, zeros) + '.' + integer.slice(zeros) + decimals
+        : '0.' + '0'.repeat(zeros) + integer + decimals;
+  } else {
+    if (decimals) zeros -= decimals.length;
+    num =
+      zeros < 0
+        ? integer + decimals.slice(0, zeros) + '.' + decimals.slice(zeros)
+        : integer + decimals + '0'.repeat(zeros);
+  }
+
+  return numberSign < 0 ? '-' + num : num;
+}

--- a/packages/shared-dependencies/package.json
+++ b/packages/shared-dependencies/package.json
@@ -60,9 +60,11 @@
     "@balancer-labs/v2-pool-weighted": "^2.0.1",
     "@balancer-labs/v2-solidity-utils": "^2.0.0",
     "@balancer-labs/v2-vault": "^2.0.0",
+    "@ethersproject/abi": "^5.4.0",
     "@ethersproject/bignumber": "^5.4.1",
+    "@ethersproject/bytes": "^5.4.0",
     "@ethersproject/constants": "^5.4.0",
-    "@ethersproject/contracts": "^5.4.1",
+    "@ethersproject/contracts": "5.4.0",
     "@ethersproject/providers": "^5.4.5"
   }
 }

--- a/packages/shared-dependencies/package.json
+++ b/packages/shared-dependencies/package.json
@@ -65,6 +65,7 @@
     "@ethersproject/bytes": "^5.4.0",
     "@ethersproject/constants": "^5.4.0",
     "@ethersproject/contracts": "5.4.0",
-    "@ethersproject/providers": "^5.4.5"
+    "@ethersproject/providers": "^5.4.5",
+    "decimal.js": "^10.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -137,6 +137,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^4.1.1
     "@typescript-eslint/parser": ^4.1.1
     chai: ^4.2.0
+    decimal.js: ^10.3.1
     eslint: ^7.32.0
     eslint-plugin-mocha-no-only: ^1.1.1
     eslint-plugin-prettier: ^4.0.0
@@ -4043,6 +4044,13 @@ __metadata:
   version: 4.0.0
   resolution: "decamelize@npm:4.0.0"
   checksum: b7d09b82652c39eead4d6678bb578e3bebd848add894b76d0f6b395bc45b2d692fb88d977e7cfb93c4ed6c119b05a1347cef261174916c2e75c0a8ca57da1809
+  languageName: node
+  linkType: hard
+
+"decimal.js@npm:^10.3.1":
+  version: 10.3.1
+  resolution: "decimal.js@npm:10.3.1"
+  checksum: 0351ac9f05fe050f23227aa6a4573bee2d58fa7378fcf28d969a8c789525032effb488a90320fd3fe86a66e17b4bc507d811b15eada5b7f0e7ec5d2af4c24a59
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,6 +73,38 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@balancer-examples/pool-permissioned@workspace:packages/pool-permissioned":
+  version: 0.0.0-use.local
+  resolution: "@balancer-examples/pool-permissioned@workspace:packages/pool-permissioned"
+  dependencies:
+    "@balancer-labs/v2-pool-utils": ^2.0.1
+    "@balancer-labs/v2-solidity-utils": ^2.0.0
+    "@balancer-labs/v2-vault": ^2.0.0
+    "@nomiclabs/hardhat-ethers": ^2.0.1
+    "@nomiclabs/hardhat-waffle": ^2.0.0
+    "@types/chai": ^4.2.12
+    "@types/mocha": ^8.0.3
+    "@types/node": ^14.6.0
+    "@typescript-eslint/eslint-plugin": ^4.1.1
+    "@typescript-eslint/parser": ^4.1.1
+    chai: ^4.2.0
+    eslint: ^7.32.0
+    eslint-plugin-mocha-no-only: ^1.1.1
+    eslint-plugin-prettier: ^4.0.0
+    ethereum-waffle: ^3.0.2
+    ethers: ^5.4.1
+    hardhat: ^2.4.1
+    mocha: ^8.2.1
+    nodemon: ^2.0.4
+    prettier: ^2.4.0
+    prettier-plugin-solidity: ^1.0.0-beta.18
+    solhint: ^3.2.0
+    solhint-plugin-prettier: ^0.0.5
+    ts-node: ^8.10.2
+    typescript: ^4.0.2
+  languageName: unknown
+  linkType: soft
+
 "@balancer-examples/shared-dependencies@workspace:packages/shared-dependencies":
   version: 0.0.0-use.local
   resolution: "@balancer-examples/shared-dependencies@workspace:packages/shared-dependencies"
@@ -109,6 +141,27 @@ __metadata:
     prettier-plugin-solidity: ^1.0.0-beta.18
     solhint: ^3.2.0
     solhint-plugin-prettier: ^0.0.5
+    ts-node: ^8.10.2
+    typescript: ^4.0.2
+  languageName: unknown
+  linkType: soft
+
+"@balancer-examples/v2-helpers@workspace:packages/helpers":
+  version: 0.0.0-use.local
+  resolution: "@balancer-examples/v2-helpers@workspace:packages/helpers"
+  dependencies:
+    "@nomiclabs/hardhat-ethers": ^2.0.1
+    "@types/lodash": ^4.14.161
+    "@types/node": ^14.6.0
+    "@typescript-eslint/eslint-plugin": ^4.1.1
+    "@typescript-eslint/parser": ^4.1.1
+    decimal.js: ^10.2.1
+    eslint: ^7.9.0
+    eslint-plugin-prettier: ^3.1.4
+    ethers: ^5.4.1
+    hardhat: ^2.8.3
+    lodash.frompairs: ^4.0.1
+    prettier: ^2.1.2
     ts-node: ^8.10.2
     typescript: ^4.0.2
   languageName: unknown
@@ -358,6 +411,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethereumjs/block@npm:^3.5.0, @ethereumjs/block@npm:^3.6.0, @ethereumjs/block@npm:^3.6.1":
+  version: 3.6.1
+  resolution: "@ethereumjs/block@npm:3.6.1"
+  dependencies:
+    "@ethereumjs/common": ^2.6.1
+    "@ethereumjs/tx": ^3.5.0
+    ethereumjs-util: ^7.1.4
+    merkle-patricia-tree: ^4.2.3
+  checksum: 91d5ab71a6fb8f6ae46a0e44aca4510d93cf5f764c45f1d3de7d9d92bdc771db9fe685c613e82c611258c73221d4aa3c2ce2920503b609896fb37d012870f2b2
+  languageName: node
+  linkType: hard
+
 "@ethereumjs/blockchain@npm:^5.4.0":
   version: 5.4.0
   resolution: "@ethereumjs/blockchain@npm:5.4.0"
@@ -375,6 +440,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethereumjs/blockchain@npm:^5.5.0, @ethereumjs/blockchain@npm:^5.5.1":
+  version: 5.5.1
+  resolution: "@ethereumjs/blockchain@npm:5.5.1"
+  dependencies:
+    "@ethereumjs/block": ^3.6.0
+    "@ethereumjs/common": ^2.6.0
+    "@ethereumjs/ethash": ^1.1.0
+    debug: ^2.2.0
+    ethereumjs-util: ^7.1.3
+    level-mem: ^5.0.1
+    lru-cache: ^5.1.1
+    semaphore-async-await: ^1.5.1
+  checksum: d4bf2941763462d83ba9267b8f49467e40eb5f900191488fe82fe0a426c03d55535f59be20598eb72f06ec9e9473a49fa0885fe56fb2cf041c2af946628e0463
+  languageName: node
+  linkType: hard
+
 "@ethereumjs/common@npm:^2.4.0":
   version: 2.4.0
   resolution: "@ethereumjs/common@npm:2.4.0"
@@ -382,6 +463,16 @@ __metadata:
     crc-32: ^1.2.0
     ethereumjs-util: ^7.1.0
   checksum: 46af3714500f24fe9586f0a65571fb9510c828699674106428f288fd0cfad667c1188f071f288184891d165edf0ed3f95440e00f062dacfcac9d871b709b5fd3
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/common@npm:^2.6.0, @ethereumjs/common@npm:^2.6.1, @ethereumjs/common@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "@ethereumjs/common@npm:2.6.2"
+  dependencies:
+    crc-32: ^1.2.0
+    ethereumjs-util: ^7.1.4
+  checksum: caa087115b5c113f6c024a5a191877ce2372edbd548ba38560505cd00165d0979c512eef9ed8242fb10f1f3391c8ac838ddc178c67008876e7192841843a84c4
   languageName: node
   linkType: hard
 
@@ -397,6 +488,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethereumjs/ethash@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@ethereumjs/ethash@npm:1.1.0"
+  dependencies:
+    "@ethereumjs/block": ^3.5.0
+    "@types/levelup": ^4.3.0
+    buffer-xor: ^2.0.1
+    ethereumjs-util: ^7.1.1
+    miller-rabin: ^4.0.0
+  checksum: 152bc0850eeb0f2507383ca005418697b0a6a4487b120d7b3fadae4cb3b4781403c96c01f0c47149031431e518fb174c284ff38806b457f86f00c500eb213df3
+  languageName: node
+  linkType: hard
+
 "@ethereumjs/tx@npm:^3.3.0":
   version: 3.3.0
   resolution: "@ethereumjs/tx@npm:3.3.0"
@@ -404,6 +508,16 @@ __metadata:
     "@ethereumjs/common": ^2.4.0
     ethereumjs-util: ^7.1.0
   checksum: f0720d4c7ccb670c50f61a3c26bf87181f3fddd4fe7f6c93753cca7c1442497719842ffb293db776c8c9a8c7107f18cb03eda3625d53cc5dda1bab736ff2a166
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/tx@npm:^3.4.0, @ethereumjs/tx@npm:^3.5.0":
+  version: 3.5.0
+  resolution: "@ethereumjs/tx@npm:3.5.0"
+  dependencies:
+    "@ethereumjs/common": ^2.6.1
+    ethereumjs-util: ^7.1.4
+  checksum: bd2b806541e59fcdfb1cbf8affe0b9681aaa29a4a8afaccab7e12f645075fe88376316661404a89b9401a29062bb98386bab46a7ff6db45136cdff782d4b7b68
   languageName: node
   linkType: hard
 
@@ -425,6 +539,26 @@ __metadata:
     rustbn.js: ~0.2.0
     util.promisify: ^1.0.1
   checksum: 4bcd54927e24ee9ac12f8ea6f2505c98745f4386e0e0f110d2b35a8da45a1dafa4197ad9deeab15ba0e5f3ae0cc272861717397495b7adfd248cd94e7d3f155c
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/vm@npm:^5.6.0":
+  version: 5.7.1
+  resolution: "@ethereumjs/vm@npm:5.7.1"
+  dependencies:
+    "@ethereumjs/block": ^3.6.1
+    "@ethereumjs/blockchain": ^5.5.1
+    "@ethereumjs/common": ^2.6.2
+    "@ethereumjs/tx": ^3.5.0
+    async-eventemitter: ^0.2.4
+    core-js-pure: ^3.0.1
+    debug: ^4.3.3
+    ethereumjs-util: ^7.1.4
+    functional-red-black-tree: ^1.0.1
+    mcl-wasm: ^0.7.1
+    merkle-patricia-tree: ^4.2.3
+    rustbn.js: ~0.2.0
+  checksum: 8d2f864ac31b118eb14f9800b2f792da85784bc568b2f20fad961c9d634992d6d94f7a4dd72b1a7496d083240bfde7a4bd14f1ae0bcbdd2915e65657c83961f6
   languageName: node
   linkType: hard
 
@@ -984,6 +1118,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-sig-util@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@metamask/eth-sig-util@npm:4.0.0"
+  dependencies:
+    ethereumjs-abi: ^0.6.8
+    ethereumjs-util: ^6.2.1
+    ethjs-util: ^0.1.6
+    tweetnacl: ^1.0.3
+    tweetnacl-util: ^0.15.1
+  checksum: 983fc1d4ba2d23d8d87024013edc38660456be978641087fa4c9ca4a1c8ea0cb33e5b6845153e3f8d76adf297d38479fcfd16ed871916fee8814cca05b85b458
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -1224,6 +1371,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solidity-parser/parser@npm:^0.14.1":
+  version: 0.14.1
+  resolution: "@solidity-parser/parser@npm:0.14.1"
+  dependencies:
+    antlr4ts: ^0.5.0-alpha.4
+  checksum: 616df6c31007710f2a99f8022fa5917968bbe83293cdc0154ba378aad405c0fc0b7af45cf2c99d159ff0b24b67c7a9bc01f80178d086c705682f2f8c7f771137
+  languageName: node
+  linkType: hard
+
 "@szmarczak/http-timer@npm:^1.1.2":
   version: 1.1.2
   resolution: "@szmarczak/http-timer@npm:1.1.2"
@@ -1315,6 +1471,13 @@ __metadata:
     "@types/level-errors": "*"
     "@types/node": "*"
   checksum: 04969bb805035960b8d6650e8f76893be7ba70267bb7012f6f00d67a0cf096ada552355629791b3f5925e9cdb6912d3fe08892c33c3c583e8fd02099b573bdd7
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:^4.14.161":
+  version: 4.14.180
+  resolution: "@types/lodash@npm:4.14.180"
+  checksum: fc42ae3473695cac6e91553f832fef8eb51a31c1c0381cafa81b00dc3efe18e279786bdda77caf0b90a8340ba2ba7aa46ae6541d69870565f775d04c89128bc1
   languageName: node
   linkType: hard
 
@@ -3325,6 +3488,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^4.1.0":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: fe75c9d5c76a7a98d45495b91b2172fa3b7a09e0cc9370e5c8feb1c567b85c4288e2b3fded7cfdd7359ac28d6b3844feb8b82b8686842e93d23c827c417e83fc
+  languageName: node
+  linkType: hard
+
 "chardet@npm:^0.7.0":
   version: 0.7.0
   resolution: "chardet@npm:0.7.0"
@@ -3383,6 +3556,25 @@ __metadata:
     fsevents:
       optional: true
   checksum: b7774e6e3aeca084d39e8542041555a11452414c744122436101243f89580fad97154ae11525e46bfa816313ae32533e2a88e8587e4d50b14ea716a9e6538978
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:3.5.3":
+  version: 3.5.3
+  resolution: "chokidar@npm:3.5.3"
+  dependencies:
+    anymatch: ~3.1.2
+    braces: ~3.0.2
+    fsevents: ~2.3.2
+    glob-parent: ~5.1.2
+    is-binary-path: ~2.1.0
+    is-glob: ~4.0.1
+    normalize-path: ~3.0.0
+    readdirp: ~3.6.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: b49fcde40176ba007ff361b198a2d35df60d9bb2a5aab228279eb810feae9294a6b4649ab15981304447afe1e6ffbf4788ad5db77235dc770ab777c6e771980c
   languageName: node
   linkType: hard
 
@@ -3970,6 +4162,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:4.3.3, debug@npm:^4.3.3":
+  version: 4.3.3
+  resolution: "debug@npm:4.3.3"
+  dependencies:
+    ms: 2.1.2
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 14472d56fe4a94dbcfaa6dbed2dd3849f1d72ba78104a1a328047bb564643ca49df0224c3a17fa63533fd11dd3d4c8636cd861191232a2c6735af00cc2d4de16
+  languageName: node
+  linkType: hard
+
 "debug@npm:^3.1.0, debug@npm:^3.2.6":
   version: 3.2.7
   resolution: "debug@npm:3.2.7"
@@ -3990,6 +4194,13 @@ __metadata:
   version: 4.0.0
   resolution: "decamelize@npm:4.0.0"
   checksum: b7d09b82652c39eead4d6678bb578e3bebd848add894b76d0f6b395bc45b2d692fb88d977e7cfb93c4ed6c119b05a1347cef261174916c2e75c0a8ca57da1809
+  languageName: node
+  linkType: hard
+
+"decimal.js@npm:^10.2.1":
+  version: 10.3.1
+  resolution: "decimal.js@npm:10.3.1"
+  checksum: 0351ac9f05fe050f23227aa6a4573bee2d58fa7378fcf28d969a8c789525032effb488a90320fd3fe86a66e17b4bc507d811b15eada5b7f0e7ec5d2af4c24a59
   languageName: node
   linkType: hard
 
@@ -4521,6 +4732,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-prettier@npm:^3.1.4":
+  version: 3.4.1
+  resolution: "eslint-plugin-prettier@npm:3.4.1"
+  dependencies:
+    prettier-linter-helpers: ^1.0.0
+  peerDependencies:
+    eslint: ">=5.0.0"
+    prettier: ">=1.13.0"
+  peerDependenciesMeta:
+    eslint-config-prettier:
+      optional: true
+  checksum: fa6a89f0d7cba1cc87064352f5a4a68dc3739448dd279bec2bced1bfa3b704467e603d13b69dcec853f8fa30b286b8b715912898e9da776e1b016cf0ee48bd99
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-prettier@npm:^4.0.0":
   version: 4.0.0
   resolution: "eslint-plugin-prettier@npm:4.0.0"
@@ -4645,7 +4871,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^7.32.0":
+"eslint@npm:^7.32.0, eslint@npm:^7.9.0":
   version: 7.32.0
   resolution: "eslint@npm:7.32.0"
   dependencies:
@@ -5123,7 +5349,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethereumjs-util@npm:6.2.1, ethereumjs-util@npm:^6.0.0, ethereumjs-util@npm:^6.1.0, ethereumjs-util@npm:^6.2.0":
+"ethereumjs-util@npm:6.2.1, ethereumjs-util@npm:^6.0.0, ethereumjs-util@npm:^6.1.0, ethereumjs-util@npm:^6.2.0, ethereumjs-util@npm:^6.2.1":
   version: 6.2.1
   resolution: "ethereumjs-util@npm:6.2.1"
   dependencies:
@@ -5177,6 +5403,19 @@ __metadata:
     ethjs-util: 0.1.6
     rlp: ^2.2.4
   checksum: bdbf89021782e921a2e25e868d6a70e8c684616bc4d5b722396773424e406810007235ed0872d27af272b1dede17a9d32415a0f88743dee699762d8de75adde8
+  languageName: node
+  linkType: hard
+
+"ethereumjs-util@npm:^7.1.1, ethereumjs-util@npm:^7.1.3, ethereumjs-util@npm:^7.1.4":
+  version: 7.1.4
+  resolution: "ethereumjs-util@npm:7.1.4"
+  dependencies:
+    "@types/bn.js": ^5.1.0
+    bn.js: ^5.1.2
+    create-hash: ^1.1.2
+    ethereum-cryptography: ^0.1.3
+    rlp: ^2.2.4
+  checksum: ccfd9208bfe9205af124a9138c5a90db46cd2fcacf4b80f17f67915381c03253aa2fb90ead9e0b53d9a6fcfeed4310e5dfa8dc516ca2846d16baf81d605cd8c2
   languageName: node
   linkType: hard
 
@@ -5325,7 +5564,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethjs-util@npm:0.1.6, ethjs-util@npm:^0.1.3":
+"ethjs-util@npm:0.1.6, ethjs-util@npm:^0.1.3, ethjs-util@npm:^0.1.6":
   version: 0.1.6
   resolution: "ethjs-util@npm:0.1.6"
   dependencies:
@@ -6134,6 +6373,20 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"glob@npm:7.2.0":
+  version: 7.2.0
+  resolution: "glob@npm:7.2.0"
+  dependencies:
+    fs.realpath: ^1.0.0
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: ^3.0.4
+    once: ^1.3.0
+    path-is-absolute: ^1.0.0
+  checksum: 78a8ea942331f08ed2e055cb5b9e40fe6f46f579d7fd3d694f3412fe5db23223d29b7fee1575440202e9a7ff9a72ab106a39fee39934c7bedafe5e5f8ae20134
+  languageName: node
+  linkType: hard
+
 "glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:~7.1.7":
   version: 7.1.7
   resolution: "glob@npm:7.1.7"
@@ -6337,6 +6590,64 @@ fsevents@~2.1.1:
   bin:
     hardhat: internal/cli/cli.js
   checksum: 378a0e2992603e11c11b80254a2c197d578f860d6d3b271251a6c6e3235698a763c991639e913388ddcb17d90e0f3e539614277242bf2e2a1a7ddbcc26259aa3
+  languageName: node
+  linkType: hard
+
+"hardhat@npm:^2.8.3":
+  version: 2.9.1
+  resolution: "hardhat@npm:2.9.1"
+  dependencies:
+    "@ethereumjs/block": ^3.6.0
+    "@ethereumjs/blockchain": ^5.5.0
+    "@ethereumjs/common": ^2.6.0
+    "@ethereumjs/tx": ^3.4.0
+    "@ethereumjs/vm": ^5.6.0
+    "@ethersproject/abi": ^5.1.2
+    "@metamask/eth-sig-util": ^4.0.0
+    "@sentry/node": ^5.18.1
+    "@solidity-parser/parser": ^0.14.1
+    "@types/bn.js": ^5.1.0
+    "@types/lru-cache": ^5.1.0
+    abort-controller: ^3.0.0
+    adm-zip: ^0.4.16
+    aggregate-error: ^3.0.0
+    ansi-escapes: ^4.3.0
+    chalk: ^2.4.2
+    chokidar: ^3.4.0
+    ci-info: ^2.0.0
+    debug: ^4.1.1
+    enquirer: ^2.3.0
+    env-paths: ^2.2.0
+    ethereum-cryptography: ^0.1.2
+    ethereumjs-abi: ^0.6.8
+    ethereumjs-util: ^7.1.3
+    find-up: ^2.1.0
+    fp-ts: 1.19.3
+    fs-extra: ^7.0.1
+    glob: ^7.1.3
+    immutable: ^4.0.0-rc.12
+    io-ts: 1.10.4
+    lodash: ^4.17.11
+    merkle-patricia-tree: ^4.2.2
+    mnemonist: ^0.38.0
+    mocha: ^9.2.0
+    p-map: ^4.0.0
+    qs: ^6.7.0
+    raw-body: ^2.4.1
+    resolve: 1.17.0
+    semver: ^6.3.0
+    slash: ^3.0.0
+    solc: 0.7.3
+    source-map-support: ^0.5.13
+    stacktrace-parser: ^0.1.10
+    true-case-path: ^2.2.1
+    tsort: 0.0.1
+    undici: ^4.14.1
+    uuid: ^8.3.2
+    ws: ^7.4.6
+  bin:
+    hardhat: internal/cli/cli.js
+  checksum: 1f622e9f0be506a1e201502c04cfe6a98339e437a067b435ec22f69c90828ab1a926ac23b920931cd3143a71a668eb7ebd471347b97e7f80d7b88021fff533c4
   languageName: node
   linkType: hard
 
@@ -7214,6 +7525,13 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"is-unicode-supported@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "is-unicode-supported@npm:0.1.0"
+  checksum: a2aab86ee7712f5c2f999180daaba5f361bdad1efadc9610ff5b8ab5495b86e4f627839d085c6530363c6d6d4ecbde340fb8e54bdb83da4ba8e0865ed5513c52
+  languageName: node
+  linkType: hard
+
 "is-url@npm:^1.2.4":
   version: 1.2.4
   resolution: "is-url@npm:1.2.4"
@@ -7353,6 +7671,17 @@ fsevents@~2.1.1:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 931d6dddb3589fa272c8273366c6dffa99fd6bd26ac7b70f9bac925c28cb7ae352b964192df84f90ecd7a2ff50ab87e6d58e2148eb19c89aa155c73ed847ab92
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:4.1.0":
+  version: 4.1.0
+  resolution: "js-yaml@npm:4.1.0"
+  dependencies:
+    argparse: ^2.0.1
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
   languageName: node
   linkType: hard
 
@@ -7943,6 +8272,13 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"lodash.frompairs@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "lodash.frompairs@npm:4.0.1"
+  checksum: 8ff2d857f0764325dba5825ef8776cfc6992a504d75d668889bdd617c62fc3f179f1590042e127c98ed14d3fb14b71e66697b0fe8b10f73879c3a46e2d1c23d3
+  languageName: node
+  linkType: hard
+
 "lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
@@ -7986,6 +8322,16 @@ fsevents@~2.1.1:
   dependencies:
     chalk: ^4.0.0
   checksum: a7c1fb5cc504ff04422460dcae3a830002426432fbed81280c8a49f4c6f5ef244c28b987636bf1c871ba6866d7024713388be391e92c0d5af6a70598fcabc46b
+  languageName: node
+  linkType: hard
+
+"log-symbols@npm:4.1.0":
+  version: 4.1.0
+  resolution: "log-symbols@npm:4.1.0"
+  dependencies:
+    chalk: ^4.1.0
+    is-unicode-supported: ^0.1.0
+  checksum: fce1497b3135a0198803f9f07464165e9eb83ed02ceb2273930a6f8a508951178d8cf4f0378e9d28300a2ed2bc49050995d2bd5f53ab716bb15ac84d58c6ef74
   languageName: node
   linkType: hard
 
@@ -8267,6 +8613,20 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"merkle-patricia-tree@npm:^4.2.2, merkle-patricia-tree@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "merkle-patricia-tree@npm:4.2.3"
+  dependencies:
+    "@types/levelup": ^4.3.0
+    ethereumjs-util: ^7.1.4
+    level-mem: ^5.0.1
+    level-ws: ^2.0.0
+    readable-stream: ^3.6.0
+    semaphore-async-await: ^1.5.1
+  checksum: f95d1ab7684b77cbd31d2ef1e6b0fc5688d57d2be0edd6af4af0593f0a0d89fdcc7fb0abb5664ba97aace0be160236bde6fb2f29ef04703e55c96c086e8b4070
+  languageName: node
+  linkType: hard
+
 "methods@npm:~1.1.2":
   version: 1.1.2
   resolution: "methods@npm:1.1.2"
@@ -8385,6 +8745,15 @@ fsevents@~2.1.1:
   dependencies:
     brace-expansion: ^1.1.7
   checksum: 66ac295f8a7b59788000ea3749938b0970344c841750abd96694f80269b926ebcafad3deeb3f1da2522978b119e6ae3a5869b63b13a7859a456b3408bd18a078
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:4.2.1":
+  version: 4.2.1
+  resolution: "minimatch@npm:4.2.1"
+  dependencies:
+    brace-expansion: ^1.1.7
+  checksum: 2b1514e3d0f29a549912f0db7ae7b82c5cab4a8f2dd0369f1c6451a325b3f12b2cf473c95873b6157bb8df183d6cf6db82ff03614b6adaaf1d7e055beccdfd01
   languageName: node
   linkType: hard
 
@@ -8600,6 +8969,41 @@ fsevents@~2.1.1:
     _mocha: bin/_mocha
     mocha: bin/mocha
   checksum: 4bcf00670580f009f9e20cc596cce5e2434d3562c468da783a8f935e38c4476435f12ecade43341cb8730b9d4987358038e76a075201d4bc51010927d3f8cd7c
+  languageName: node
+  linkType: hard
+
+"mocha@npm:^9.2.0":
+  version: 9.2.2
+  resolution: "mocha@npm:9.2.2"
+  dependencies:
+    "@ungap/promise-all-settled": 1.1.2
+    ansi-colors: 4.1.1
+    browser-stdout: 1.3.1
+    chokidar: 3.5.3
+    debug: 4.3.3
+    diff: 5.0.0
+    escape-string-regexp: 4.0.0
+    find-up: 5.0.0
+    glob: 7.2.0
+    growl: 1.10.5
+    he: 1.2.0
+    js-yaml: 4.1.0
+    log-symbols: 4.1.0
+    minimatch: 4.2.1
+    ms: 2.1.3
+    nanoid: 3.3.1
+    serialize-javascript: 6.0.0
+    strip-json-comments: 3.1.1
+    supports-color: 8.1.1
+    which: 2.0.2
+    workerpool: 6.2.0
+    yargs: 16.2.0
+    yargs-parser: 20.2.4
+    yargs-unparser: 2.0.0
+  bin:
+    _mocha: bin/_mocha
+    mocha: bin/mocha
+  checksum: 4d5ca4ce33fc66627e63acdf09a634e2358c9a00f61de7788b1091b6aad430da04f97f9ecb82d56dc034b623cb833b65576136fd010d77679c03fcea5bc1e12d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,9 +77,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@balancer-examples/pool-permissioned@workspace:packages/pool-permissioned"
   dependencies:
+    "@balancer-labs/typechain": ^1.0.0
+    "@balancer-labs/v2-deployments": ^2.0.1
     "@balancer-labs/v2-pool-utils": ^2.0.1
     "@balancer-labs/v2-solidity-utils": ^2.0.0
     "@balancer-labs/v2-vault": ^2.0.0
+    "@ethersproject/abi": ^5.4.0
+    "@ethersproject/bytes": ^5.4.0
+    "@ethersproject/constants": ^5.4.0
+    "@ethersproject/contracts": 5.4.0
+    "@ethersproject/providers": ^5.4.5
     "@nomiclabs/hardhat-ethers": ^2.0.1
     "@nomiclabs/hardhat-waffle": ^2.0.0
     "@types/chai": ^4.2.12
@@ -115,9 +122,11 @@ __metadata:
     "@balancer-labs/v2-pool-weighted": ^2.0.1
     "@balancer-labs/v2-solidity-utils": ^2.0.0
     "@balancer-labs/v2-vault": ^2.0.0
+    "@ethersproject/abi": ^5.4.0
     "@ethersproject/bignumber": ^5.4.1
+    "@ethersproject/bytes": ^5.4.0
     "@ethersproject/constants": ^5.4.0
-    "@ethersproject/contracts": ^5.4.1
+    "@ethersproject/contracts": 5.4.0
     "@ethersproject/providers": ^5.4.5
     "@nomiclabs/hardhat-ethers": ^2.0.1
     "@nomiclabs/hardhat-waffle": ^2.0.0
@@ -141,27 +150,6 @@ __metadata:
     prettier-plugin-solidity: ^1.0.0-beta.18
     solhint: ^3.2.0
     solhint-plugin-prettier: ^0.0.5
-    ts-node: ^8.10.2
-    typescript: ^4.0.2
-  languageName: unknown
-  linkType: soft
-
-"@balancer-examples/v2-helpers@workspace:packages/helpers":
-  version: 0.0.0-use.local
-  resolution: "@balancer-examples/v2-helpers@workspace:packages/helpers"
-  dependencies:
-    "@nomiclabs/hardhat-ethers": ^2.0.1
-    "@types/lodash": ^4.14.161
-    "@types/node": ^14.6.0
-    "@typescript-eslint/eslint-plugin": ^4.1.1
-    "@typescript-eslint/parser": ^4.1.1
-    decimal.js: ^10.2.1
-    eslint: ^7.9.0
-    eslint-plugin-prettier: ^3.1.4
-    ethers: ^5.4.1
-    hardhat: ^2.8.3
-    lodash.frompairs: ^4.0.1
-    prettier: ^2.1.2
     ts-node: ^8.10.2
     typescript: ^4.0.2
   languageName: unknown
@@ -199,7 +187,9 @@ __metadata:
     "@balancer-labs/v2-pool-weighted": ^2.0.1
     "@balancer-labs/v2-solidity-utils": ^2.0.0
     "@balancer-labs/v2-vault": ^2.0.0
+    "@ethersproject/abi": ^5.4.0
     "@ethersproject/bignumber": ^5.4.1
+    "@ethersproject/bytes": ^5.4.0
     "@ethersproject/constants": ^5.4.0
     "@ethersproject/contracts": ^5.4.1
     "@ethersproject/providers": ^5.4.5
@@ -248,6 +238,16 @@ __metadata:
     "@balancer-labs/v2-solidity-utils": 2.0.0
     "@balancer-labs/v2-vault": 2.0.0
   checksum: 5291b2e18ea39f10b12a76ea220b595f733a8ee3257ae360a1c8415a16db3c96c914605cb363d3179963997152226aca1553008e7533dd13f250e9ac1580df64
+  languageName: node
+  linkType: hard
+
+"@balancer-labs/v2-deployments@npm:^2.0.1":
+  version: 2.3.0
+  resolution: "@balancer-labs/v2-deployments@npm:2.3.0"
+  peerDependencies:
+    "@nomiclabs/hardhat-ethers": ^2.0.1
+    hardhat: ^2.4.1
+  checksum: ff639d7090d0e0075522fde384d47a048a0e079eddce45f22ed0e909807e0b4bfcd90c8c32de2f383628b98105b3ae2ac99e57ab24f65abc316451f329ee55ec
   languageName: node
   linkType: hard
 
@@ -411,18 +411,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/block@npm:^3.5.0, @ethereumjs/block@npm:^3.6.0, @ethereumjs/block@npm:^3.6.1":
-  version: 3.6.1
-  resolution: "@ethereumjs/block@npm:3.6.1"
-  dependencies:
-    "@ethereumjs/common": ^2.6.1
-    "@ethereumjs/tx": ^3.5.0
-    ethereumjs-util: ^7.1.4
-    merkle-patricia-tree: ^4.2.3
-  checksum: 91d5ab71a6fb8f6ae46a0e44aca4510d93cf5f764c45f1d3de7d9d92bdc771db9fe685c613e82c611258c73221d4aa3c2ce2920503b609896fb37d012870f2b2
-  languageName: node
-  linkType: hard
-
 "@ethereumjs/blockchain@npm:^5.4.0":
   version: 5.4.0
   resolution: "@ethereumjs/blockchain@npm:5.4.0"
@@ -440,22 +428,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/blockchain@npm:^5.5.0, @ethereumjs/blockchain@npm:^5.5.1":
-  version: 5.5.1
-  resolution: "@ethereumjs/blockchain@npm:5.5.1"
-  dependencies:
-    "@ethereumjs/block": ^3.6.0
-    "@ethereumjs/common": ^2.6.0
-    "@ethereumjs/ethash": ^1.1.0
-    debug: ^2.2.0
-    ethereumjs-util: ^7.1.3
-    level-mem: ^5.0.1
-    lru-cache: ^5.1.1
-    semaphore-async-await: ^1.5.1
-  checksum: d4bf2941763462d83ba9267b8f49467e40eb5f900191488fe82fe0a426c03d55535f59be20598eb72f06ec9e9473a49fa0885fe56fb2cf041c2af946628e0463
-  languageName: node
-  linkType: hard
-
 "@ethereumjs/common@npm:^2.4.0":
   version: 2.4.0
   resolution: "@ethereumjs/common@npm:2.4.0"
@@ -463,16 +435,6 @@ __metadata:
     crc-32: ^1.2.0
     ethereumjs-util: ^7.1.0
   checksum: 46af3714500f24fe9586f0a65571fb9510c828699674106428f288fd0cfad667c1188f071f288184891d165edf0ed3f95440e00f062dacfcac9d871b709b5fd3
-  languageName: node
-  linkType: hard
-
-"@ethereumjs/common@npm:^2.6.0, @ethereumjs/common@npm:^2.6.1, @ethereumjs/common@npm:^2.6.2":
-  version: 2.6.2
-  resolution: "@ethereumjs/common@npm:2.6.2"
-  dependencies:
-    crc-32: ^1.2.0
-    ethereumjs-util: ^7.1.4
-  checksum: caa087115b5c113f6c024a5a191877ce2372edbd548ba38560505cd00165d0979c512eef9ed8242fb10f1f3391c8ac838ddc178c67008876e7192841843a84c4
   languageName: node
   linkType: hard
 
@@ -488,19 +450,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/ethash@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@ethereumjs/ethash@npm:1.1.0"
-  dependencies:
-    "@ethereumjs/block": ^3.5.0
-    "@types/levelup": ^4.3.0
-    buffer-xor: ^2.0.1
-    ethereumjs-util: ^7.1.1
-    miller-rabin: ^4.0.0
-  checksum: 152bc0850eeb0f2507383ca005418697b0a6a4487b120d7b3fadae4cb3b4781403c96c01f0c47149031431e518fb174c284ff38806b457f86f00c500eb213df3
-  languageName: node
-  linkType: hard
-
 "@ethereumjs/tx@npm:^3.3.0":
   version: 3.3.0
   resolution: "@ethereumjs/tx@npm:3.3.0"
@@ -508,16 +457,6 @@ __metadata:
     "@ethereumjs/common": ^2.4.0
     ethereumjs-util: ^7.1.0
   checksum: f0720d4c7ccb670c50f61a3c26bf87181f3fddd4fe7f6c93753cca7c1442497719842ffb293db776c8c9a8c7107f18cb03eda3625d53cc5dda1bab736ff2a166
-  languageName: node
-  linkType: hard
-
-"@ethereumjs/tx@npm:^3.4.0, @ethereumjs/tx@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@ethereumjs/tx@npm:3.5.0"
-  dependencies:
-    "@ethereumjs/common": ^2.6.1
-    ethereumjs-util: ^7.1.4
-  checksum: bd2b806541e59fcdfb1cbf8affe0b9681aaa29a4a8afaccab7e12f645075fe88376316661404a89b9401a29062bb98386bab46a7ff6db45136cdff782d4b7b68
   languageName: node
   linkType: hard
 
@@ -539,26 +478,6 @@ __metadata:
     rustbn.js: ~0.2.0
     util.promisify: ^1.0.1
   checksum: 4bcd54927e24ee9ac12f8ea6f2505c98745f4386e0e0f110d2b35a8da45a1dafa4197ad9deeab15ba0e5f3ae0cc272861717397495b7adfd248cd94e7d3f155c
-  languageName: node
-  linkType: hard
-
-"@ethereumjs/vm@npm:^5.6.0":
-  version: 5.7.1
-  resolution: "@ethereumjs/vm@npm:5.7.1"
-  dependencies:
-    "@ethereumjs/block": ^3.6.1
-    "@ethereumjs/blockchain": ^5.5.1
-    "@ethereumjs/common": ^2.6.2
-    "@ethereumjs/tx": ^3.5.0
-    async-eventemitter: ^0.2.4
-    core-js-pure: ^3.0.1
-    debug: ^4.3.3
-    ethereumjs-util: ^7.1.4
-    functional-red-black-tree: ^1.0.1
-    mcl-wasm: ^0.7.1
-    merkle-patricia-tree: ^4.2.3
-    rustbn.js: ~0.2.0
-  checksum: 8d2f864ac31b118eb14f9800b2f792da85784bc568b2f20fad961c9d634992d6d94f7a4dd72b1a7496d083240bfde7a4bd14f1ae0bcbdd2915e65657c83961f6
   languageName: node
   linkType: hard
 
@@ -1118,19 +1037,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-sig-util@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@metamask/eth-sig-util@npm:4.0.0"
-  dependencies:
-    ethereumjs-abi: ^0.6.8
-    ethereumjs-util: ^6.2.1
-    ethjs-util: ^0.1.6
-    tweetnacl: ^1.0.3
-    tweetnacl-util: ^0.15.1
-  checksum: 983fc1d4ba2d23d8d87024013edc38660456be978641087fa4c9ca4a1c8ea0cb33e5b6845153e3f8d76adf297d38479fcfd16ed871916fee8814cca05b85b458
-  languageName: node
-  linkType: hard
-
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -1371,15 +1277,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solidity-parser/parser@npm:^0.14.1":
-  version: 0.14.1
-  resolution: "@solidity-parser/parser@npm:0.14.1"
-  dependencies:
-    antlr4ts: ^0.5.0-alpha.4
-  checksum: 616df6c31007710f2a99f8022fa5917968bbe83293cdc0154ba378aad405c0fc0b7af45cf2c99d159ff0b24b67c7a9bc01f80178d086c705682f2f8c7f771137
-  languageName: node
-  linkType: hard
-
 "@szmarczak/http-timer@npm:^1.1.2":
   version: 1.1.2
   resolution: "@szmarczak/http-timer@npm:1.1.2"
@@ -1471,13 +1368,6 @@ __metadata:
     "@types/level-errors": "*"
     "@types/node": "*"
   checksum: 04969bb805035960b8d6650e8f76893be7ba70267bb7012f6f00d67a0cf096ada552355629791b3f5925e9cdb6912d3fe08892c33c3c583e8fd02099b573bdd7
-  languageName: node
-  linkType: hard
-
-"@types/lodash@npm:^4.14.161":
-  version: 4.14.180
-  resolution: "@types/lodash@npm:4.14.180"
-  checksum: fc42ae3473695cac6e91553f832fef8eb51a31c1c0381cafa81b00dc3efe18e279786bdda77caf0b90a8340ba2ba7aa46ae6541d69870565f775d04c89128bc1
   languageName: node
   linkType: hard
 
@@ -3488,16 +3378,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.1.0":
-  version: 4.1.2
-  resolution: "chalk@npm:4.1.2"
-  dependencies:
-    ansi-styles: ^4.1.0
-    supports-color: ^7.1.0
-  checksum: fe75c9d5c76a7a98d45495b91b2172fa3b7a09e0cc9370e5c8feb1c567b85c4288e2b3fded7cfdd7359ac28d6b3844feb8b82b8686842e93d23c827c417e83fc
-  languageName: node
-  linkType: hard
-
 "chardet@npm:^0.7.0":
   version: 0.7.0
   resolution: "chardet@npm:0.7.0"
@@ -3556,25 +3436,6 @@ __metadata:
     fsevents:
       optional: true
   checksum: b7774e6e3aeca084d39e8542041555a11452414c744122436101243f89580fad97154ae11525e46bfa816313ae32533e2a88e8587e4d50b14ea716a9e6538978
-  languageName: node
-  linkType: hard
-
-"chokidar@npm:3.5.3":
-  version: 3.5.3
-  resolution: "chokidar@npm:3.5.3"
-  dependencies:
-    anymatch: ~3.1.2
-    braces: ~3.0.2
-    fsevents: ~2.3.2
-    glob-parent: ~5.1.2
-    is-binary-path: ~2.1.0
-    is-glob: ~4.0.1
-    normalize-path: ~3.0.0
-    readdirp: ~3.6.0
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: b49fcde40176ba007ff361b198a2d35df60d9bb2a5aab228279eb810feae9294a6b4649ab15981304447afe1e6ffbf4788ad5db77235dc770ab777c6e771980c
   languageName: node
   linkType: hard
 
@@ -4162,18 +4023,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4.3.3, debug@npm:^4.3.3":
-  version: 4.3.3
-  resolution: "debug@npm:4.3.3"
-  dependencies:
-    ms: 2.1.2
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 14472d56fe4a94dbcfaa6dbed2dd3849f1d72ba78104a1a328047bb564643ca49df0224c3a17fa63533fd11dd3d4c8636cd861191232a2c6735af00cc2d4de16
-  languageName: node
-  linkType: hard
-
 "debug@npm:^3.1.0, debug@npm:^3.2.6":
   version: 3.2.7
   resolution: "debug@npm:3.2.7"
@@ -4194,13 +4043,6 @@ __metadata:
   version: 4.0.0
   resolution: "decamelize@npm:4.0.0"
   checksum: b7d09b82652c39eead4d6678bb578e3bebd848add894b76d0f6b395bc45b2d692fb88d977e7cfb93c4ed6c119b05a1347cef261174916c2e75c0a8ca57da1809
-  languageName: node
-  linkType: hard
-
-"decimal.js@npm:^10.2.1":
-  version: 10.3.1
-  resolution: "decimal.js@npm:10.3.1"
-  checksum: 0351ac9f05fe050f23227aa6a4573bee2d58fa7378fcf28d969a8c789525032effb488a90320fd3fe86a66e17b4bc507d811b15eada5b7f0e7ec5d2af4c24a59
   languageName: node
   linkType: hard
 
@@ -4732,21 +4574,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-prettier@npm:^3.1.4":
-  version: 3.4.1
-  resolution: "eslint-plugin-prettier@npm:3.4.1"
-  dependencies:
-    prettier-linter-helpers: ^1.0.0
-  peerDependencies:
-    eslint: ">=5.0.0"
-    prettier: ">=1.13.0"
-  peerDependenciesMeta:
-    eslint-config-prettier:
-      optional: true
-  checksum: fa6a89f0d7cba1cc87064352f5a4a68dc3739448dd279bec2bced1bfa3b704467e603d13b69dcec853f8fa30b286b8b715912898e9da776e1b016cf0ee48bd99
-  languageName: node
-  linkType: hard
-
 "eslint-plugin-prettier@npm:^4.0.0":
   version: 4.0.0
   resolution: "eslint-plugin-prettier@npm:4.0.0"
@@ -4871,7 +4698,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^7.32.0, eslint@npm:^7.9.0":
+"eslint@npm:^7.32.0":
   version: 7.32.0
   resolution: "eslint@npm:7.32.0"
   dependencies:
@@ -5349,7 +5176,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethereumjs-util@npm:6.2.1, ethereumjs-util@npm:^6.0.0, ethereumjs-util@npm:^6.1.0, ethereumjs-util@npm:^6.2.0, ethereumjs-util@npm:^6.2.1":
+"ethereumjs-util@npm:6.2.1, ethereumjs-util@npm:^6.0.0, ethereumjs-util@npm:^6.1.0, ethereumjs-util@npm:^6.2.0":
   version: 6.2.1
   resolution: "ethereumjs-util@npm:6.2.1"
   dependencies:
@@ -5403,19 +5230,6 @@ __metadata:
     ethjs-util: 0.1.6
     rlp: ^2.2.4
   checksum: bdbf89021782e921a2e25e868d6a70e8c684616bc4d5b722396773424e406810007235ed0872d27af272b1dede17a9d32415a0f88743dee699762d8de75adde8
-  languageName: node
-  linkType: hard
-
-"ethereumjs-util@npm:^7.1.1, ethereumjs-util@npm:^7.1.3, ethereumjs-util@npm:^7.1.4":
-  version: 7.1.4
-  resolution: "ethereumjs-util@npm:7.1.4"
-  dependencies:
-    "@types/bn.js": ^5.1.0
-    bn.js: ^5.1.2
-    create-hash: ^1.1.2
-    ethereum-cryptography: ^0.1.3
-    rlp: ^2.2.4
-  checksum: ccfd9208bfe9205af124a9138c5a90db46cd2fcacf4b80f17f67915381c03253aa2fb90ead9e0b53d9a6fcfeed4310e5dfa8dc516ca2846d16baf81d605cd8c2
   languageName: node
   linkType: hard
 
@@ -5564,7 +5378,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethjs-util@npm:0.1.6, ethjs-util@npm:^0.1.3, ethjs-util@npm:^0.1.6":
+"ethjs-util@npm:0.1.6, ethjs-util@npm:^0.1.3":
   version: 0.1.6
   resolution: "ethjs-util@npm:0.1.6"
   dependencies:
@@ -6373,20 +6187,6 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"glob@npm:7.2.0":
-  version: 7.2.0
-  resolution: "glob@npm:7.2.0"
-  dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^3.0.4
-    once: ^1.3.0
-    path-is-absolute: ^1.0.0
-  checksum: 78a8ea942331f08ed2e055cb5b9e40fe6f46f579d7fd3d694f3412fe5db23223d29b7fee1575440202e9a7ff9a72ab106a39fee39934c7bedafe5e5f8ae20134
-  languageName: node
-  linkType: hard
-
 "glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:~7.1.7":
   version: 7.1.7
   resolution: "glob@npm:7.1.7"
@@ -6590,64 +6390,6 @@ fsevents@~2.1.1:
   bin:
     hardhat: internal/cli/cli.js
   checksum: 378a0e2992603e11c11b80254a2c197d578f860d6d3b271251a6c6e3235698a763c991639e913388ddcb17d90e0f3e539614277242bf2e2a1a7ddbcc26259aa3
-  languageName: node
-  linkType: hard
-
-"hardhat@npm:^2.8.3":
-  version: 2.9.1
-  resolution: "hardhat@npm:2.9.1"
-  dependencies:
-    "@ethereumjs/block": ^3.6.0
-    "@ethereumjs/blockchain": ^5.5.0
-    "@ethereumjs/common": ^2.6.0
-    "@ethereumjs/tx": ^3.4.0
-    "@ethereumjs/vm": ^5.6.0
-    "@ethersproject/abi": ^5.1.2
-    "@metamask/eth-sig-util": ^4.0.0
-    "@sentry/node": ^5.18.1
-    "@solidity-parser/parser": ^0.14.1
-    "@types/bn.js": ^5.1.0
-    "@types/lru-cache": ^5.1.0
-    abort-controller: ^3.0.0
-    adm-zip: ^0.4.16
-    aggregate-error: ^3.0.0
-    ansi-escapes: ^4.3.0
-    chalk: ^2.4.2
-    chokidar: ^3.4.0
-    ci-info: ^2.0.0
-    debug: ^4.1.1
-    enquirer: ^2.3.0
-    env-paths: ^2.2.0
-    ethereum-cryptography: ^0.1.2
-    ethereumjs-abi: ^0.6.8
-    ethereumjs-util: ^7.1.3
-    find-up: ^2.1.0
-    fp-ts: 1.19.3
-    fs-extra: ^7.0.1
-    glob: ^7.1.3
-    immutable: ^4.0.0-rc.12
-    io-ts: 1.10.4
-    lodash: ^4.17.11
-    merkle-patricia-tree: ^4.2.2
-    mnemonist: ^0.38.0
-    mocha: ^9.2.0
-    p-map: ^4.0.0
-    qs: ^6.7.0
-    raw-body: ^2.4.1
-    resolve: 1.17.0
-    semver: ^6.3.0
-    slash: ^3.0.0
-    solc: 0.7.3
-    source-map-support: ^0.5.13
-    stacktrace-parser: ^0.1.10
-    true-case-path: ^2.2.1
-    tsort: 0.0.1
-    undici: ^4.14.1
-    uuid: ^8.3.2
-    ws: ^7.4.6
-  bin:
-    hardhat: internal/cli/cli.js
-  checksum: 1f622e9f0be506a1e201502c04cfe6a98339e437a067b435ec22f69c90828ab1a926ac23b920931cd3143a71a668eb7ebd471347b97e7f80d7b88021fff533c4
   languageName: node
   linkType: hard
 
@@ -7525,13 +7267,6 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"is-unicode-supported@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "is-unicode-supported@npm:0.1.0"
-  checksum: a2aab86ee7712f5c2f999180daaba5f361bdad1efadc9610ff5b8ab5495b86e4f627839d085c6530363c6d6d4ecbde340fb8e54bdb83da4ba8e0865ed5513c52
-  languageName: node
-  linkType: hard
-
 "is-url@npm:^1.2.4":
   version: 1.2.4
   resolution: "is-url@npm:1.2.4"
@@ -7671,17 +7406,6 @@ fsevents@~2.1.1:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 931d6dddb3589fa272c8273366c6dffa99fd6bd26ac7b70f9bac925c28cb7ae352b964192df84f90ecd7a2ff50ab87e6d58e2148eb19c89aa155c73ed847ab92
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:4.1.0":
-  version: 4.1.0
-  resolution: "js-yaml@npm:4.1.0"
-  dependencies:
-    argparse: ^2.0.1
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
   languageName: node
   linkType: hard
 
@@ -8272,13 +7996,6 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"lodash.frompairs@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "lodash.frompairs@npm:4.0.1"
-  checksum: 8ff2d857f0764325dba5825ef8776cfc6992a504d75d668889bdd617c62fc3f179f1590042e127c98ed14d3fb14b71e66697b0fe8b10f73879c3a46e2d1c23d3
-  languageName: node
-  linkType: hard
-
 "lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
@@ -8322,16 +8039,6 @@ fsevents@~2.1.1:
   dependencies:
     chalk: ^4.0.0
   checksum: a7c1fb5cc504ff04422460dcae3a830002426432fbed81280c8a49f4c6f5ef244c28b987636bf1c871ba6866d7024713388be391e92c0d5af6a70598fcabc46b
-  languageName: node
-  linkType: hard
-
-"log-symbols@npm:4.1.0":
-  version: 4.1.0
-  resolution: "log-symbols@npm:4.1.0"
-  dependencies:
-    chalk: ^4.1.0
-    is-unicode-supported: ^0.1.0
-  checksum: fce1497b3135a0198803f9f07464165e9eb83ed02ceb2273930a6f8a508951178d8cf4f0378e9d28300a2ed2bc49050995d2bd5f53ab716bb15ac84d58c6ef74
   languageName: node
   linkType: hard
 
@@ -8613,20 +8320,6 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"merkle-patricia-tree@npm:^4.2.2, merkle-patricia-tree@npm:^4.2.3":
-  version: 4.2.3
-  resolution: "merkle-patricia-tree@npm:4.2.3"
-  dependencies:
-    "@types/levelup": ^4.3.0
-    ethereumjs-util: ^7.1.4
-    level-mem: ^5.0.1
-    level-ws: ^2.0.0
-    readable-stream: ^3.6.0
-    semaphore-async-await: ^1.5.1
-  checksum: f95d1ab7684b77cbd31d2ef1e6b0fc5688d57d2be0edd6af4af0593f0a0d89fdcc7fb0abb5664ba97aace0be160236bde6fb2f29ef04703e55c96c086e8b4070
-  languageName: node
-  linkType: hard
-
 "methods@npm:~1.1.2":
   version: 1.1.2
   resolution: "methods@npm:1.1.2"
@@ -8745,15 +8438,6 @@ fsevents@~2.1.1:
   dependencies:
     brace-expansion: ^1.1.7
   checksum: 66ac295f8a7b59788000ea3749938b0970344c841750abd96694f80269b926ebcafad3deeb3f1da2522978b119e6ae3a5869b63b13a7859a456b3408bd18a078
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:4.2.1":
-  version: 4.2.1
-  resolution: "minimatch@npm:4.2.1"
-  dependencies:
-    brace-expansion: ^1.1.7
-  checksum: 2b1514e3d0f29a549912f0db7ae7b82c5cab4a8f2dd0369f1c6451a325b3f12b2cf473c95873b6157bb8df183d6cf6db82ff03614b6adaaf1d7e055beccdfd01
   languageName: node
   linkType: hard
 
@@ -8969,41 +8653,6 @@ fsevents@~2.1.1:
     _mocha: bin/_mocha
     mocha: bin/mocha
   checksum: 4bcf00670580f009f9e20cc596cce5e2434d3562c468da783a8f935e38c4476435f12ecade43341cb8730b9d4987358038e76a075201d4bc51010927d3f8cd7c
-  languageName: node
-  linkType: hard
-
-"mocha@npm:^9.2.0":
-  version: 9.2.2
-  resolution: "mocha@npm:9.2.2"
-  dependencies:
-    "@ungap/promise-all-settled": 1.1.2
-    ansi-colors: 4.1.1
-    browser-stdout: 1.3.1
-    chokidar: 3.5.3
-    debug: 4.3.3
-    diff: 5.0.0
-    escape-string-regexp: 4.0.0
-    find-up: 5.0.0
-    glob: 7.2.0
-    growl: 1.10.5
-    he: 1.2.0
-    js-yaml: 4.1.0
-    log-symbols: 4.1.0
-    minimatch: 4.2.1
-    ms: 2.1.3
-    nanoid: 3.3.1
-    serialize-javascript: 6.0.0
-    strip-json-comments: 3.1.1
-    supports-color: 8.1.1
-    which: 2.0.2
-    workerpool: 6.2.0
-    yargs: 16.2.0
-    yargs-parser: 20.2.4
-    yargs-unparser: 2.0.0
-  bin:
-    _mocha: bin/_mocha
-    mocha: bin/mocha
-  checksum: 4d5ca4ce33fc66627e63acdf09a634e2358c9a00f61de7788b1091b6aad430da04f97f9ecb82d56dc034b623cb833b65576136fd010d77679c03fcea5bc1e12d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
MVP example of a permissioned pool that only allows participants on an allowlist
- Allowlist is the same for traders and liquidity providers
- Allowlist can be updated by a single owner, and shared between pools
- Likely future implementations should allow recourse for allowlist removal, such as still being able to exit a pool
- `SwapRequest` is passed as criteria for allowing/rejecting a swap, to support decisions based on amount, or userdata (such as a permit schem/zk proof)

Reference implementations of interest for KYC allowlists
- Verite (a circle project) https://github.com/centrehq/verite/blob/main/packages/contract/contracts/IVerificationRegistry.sol
- FireBlocks (provider for Aave Arc)
- Stakewise allowlist manager https://goerli.etherscan.io/address/0x5dfa570a198dbd9bc47610b7a14e61c2f636392f#code